### PR TITLE
adds configuration to Hyperdrive

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: eb882f02511f62e7b13eb790ba12d7c79db16690d90017ec3b3e2dcbf58a3d57
-updated: 2017-03-03T17:59:26.101988064-06:00
+hash: 508e9b0af06800b503a5a78fd5830652f290132373e8e00ad0dbf736c04d3dcc
+updated: 2017-03-04T17:36:31.02597264-06:00
 imports:
+- name: github.com/caarlos0/env
+  version: d0de832ed2fbc4e7bfaa30ab5cf0b3417d15f529
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/handlers

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,8 @@ import:
   version: ^1.3.0
 - package: github.com/gorilla/handlers
   version: ^1.2.0
+- package: github.com/caarlos0/env
+  version: ^2.1.0
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -11,8 +11,11 @@
 package hyperdrive
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 
+	"github.com/caarlos0/env"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
@@ -26,6 +29,7 @@ type API struct {
 
 // NewAPI creates an instance of an API with an initialized Router.
 func NewAPI() API {
+	NewConfig()
 	return API{Router: mux.NewRouter()}
 }
 
@@ -150,4 +154,28 @@ func (e *Endpoint) GetPath() string {
 // NewEndpoint creates an instance of Endpoint.
 func NewEndpoint(name string, desc string, path string) *Endpoint {
 	return &Endpoint{EndpointName: name, EndpointDesc: desc, EndpointPath: path}
+}
+
+// Config holds configuration values from the environment, with sane defaults
+// (where possible). Required configuration will throw a Fatal error if they
+// are missing.
+type Config struct {
+	Port int    `env:"PORT" envDefault:"5000"`
+	Env  string `env:"HYPERDRIVE_ENVIRONMENT" envDefault:"development"`
+}
+
+// GetPort returns the formatted value of config.Port, for use by the
+// hyperdrive server, e.g. ":5000".
+func (c *Config) GetPort() string {
+	return fmt.Sprintf(":%d", c.Port)
+}
+
+// NewConfig returns an instance of config, with values loaded from ENV vars.
+func NewConfig() Config {
+	c := Config{}
+	err := env.Parse(&c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return c
 }

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -1,6 +1,7 @@
 package hyperdrive
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -37,6 +38,37 @@ func (suite *HyperdriveTestSuite) TestGetPath() {
 
 func (suite *HyperdriveTestSuite) TestEndpointer() {
 	suite.Implements((*Endpointer)(nil), suite.Endpoint, "expects an implementation of hyperdrive.Endpointer interface")
+}
+
+func (suite *HyperdriveTestSuite) TestNewConfig() {
+	suite.IsType(Config{}, NewConfig(), "expects an instance of *hyperdrive.config")
+}
+
+func (suite *HyperdriveTestSuite) TestPortConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal(5000, c.Port, "Port should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestPortConfigFromEnv() {
+	os.Setenv("PORT", "5001")
+	c := NewConfig()
+	suite.Equal(5001, c.Port, "Port should be equal to PORT value set via ENV var")
+}
+
+func (suite *HyperdriveTestSuite) TestGetPort() {
+	c := NewConfig()
+	suite.Equal(":5000", c.GetPort(), "c.Port value should be return, prefixed with a colon, e.g. :5000")
+}
+
+func (suite *HyperdriveTestSuite) TestEnvConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal("development", c.Env, "Env should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestEnvConfigFromEnv() {
+	os.Setenv("HYPERDRIVE_ENVIRONMENT", "test")
+	c := NewConfig()
+	suite.Equal("test", c.Env, "Env should be equal to HYPERDRIVE_ENVIRONMENT value set via ENV var")
 }
 
 func TestHyperdriveTestSuite(t *testing.T) {

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
-set -ex
-golint
+
+set -e
+golint -set_exit_status
 go test $(glide novendor)


### PR DESCRIPTION
- currently supports loading `Config` from env vars
  - `PORT` expects an int. defaults to: `5000`
  - `HYPERDRIVE_ENVIRONMENT` expects a string, defaults to: `development`

fixes #9