### PR TITLE
adds panic recovery middleware

### DIFF
--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -71,14 +71,14 @@ func (api *API) AddEndpoint(e Endpointer) {
 		handler["OPTIONS"] = http.HandlerFunc(h.Options)
 	}
 
-	middleware := LoggingMiddleware(http.HandlerFunc(handler.ServeHTTP))
+	middleware := api.LoggingMiddleware(api.RecoveryMiddleware(http.HandlerFunc(handler.ServeHTTP)))
 	api.Router.Handle(e.GetPath(), middleware)
 }
 
 // Start starts the configured http server, listening on the configured Port
 // (default: 5000). Set the PORT environment variable to change this.
 func (api *API) Start() {
-	log.Printf("Hyperdrive API starting on PORT %d", api.conf.Port)
+	log.Printf("Hyperdrive API starting on PORT %d in ENVIRONMENT %s", api.conf.Port, api.conf.Env)
 	log.Fatal(api.Server.ListenAndServe())
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -7,8 +7,15 @@ import (
 	"github.com/gorilla/handlers"
 )
 
-// LoggingMiddleware wraps http.Handlers and outputs requests in Apache-style
+// LoggingMiddleware wraps the given http.Handler and outputs requests in Apache-style
 // Combined Log format. All logging is done to STDOUT only.
-func LoggingMiddleware(h http.Handler) http.Handler {
+func (api *API) LoggingMiddleware(h http.Handler) http.Handler {
 	return handlers.CombinedLoggingHandler(os.Stdout, h)
+}
+
+// RecoveryMiddleware wraps the given http.Handler and recovers from panics. It wil log
+// the stacktrace if HYPERDRIVE_ENVIRONMENT env var is not set to "production".
+func (api *API) RecoveryMiddleware(h http.Handler) http.Handler {
+	opt := handlers.PrintRecoveryStack(api.conf.Env != "production")
+	return handlers.RecoveryHandler(opt)(h)
 }


### PR DESCRIPTION
- all panics are recovered, but stack traces are only logged in
non-production environments.
- outputs `api.conf.Env` during startup log

fixes #6