### PR TITLE
adds support for GZip compression, via Accept-Encoding header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ OR
 
     glide get github.com/hyperdriven/hyperdrive
 
+## Config
+
+Configuration of core features are done via Environment Variables, in accordence with [12 factor](https://12factor.net/config) principles.
+
+- `HYPERDRIVE_ENV`: (default: `development`, type: `string`) The stage in your deployment pipeline the api is currently running in. A value of `production` changes behviour for some features (such as whether stack traces are logged during panic recovery). Other values, such as `staging`, can be used but currently have no meanin in the framework other than the one you give it in your own code.
+- `PORT` - (default: `5000`, type: `int`) The port the server should listen on.
+- `GZIP_LEVEL` - (default: `-1`, type: `int`) Accepts a value between `-2` and `9`. Invalid values will be silently discarded and the default of `-1` will be used. More info on compression levels can be found in the docs, but corresponds to `zlib` compression levels.
+
 ## Docs
 
   - [GoDoc](https://godoc.org/github.com/hyperdriven/hyperdrive)

--- a/config.go
+++ b/config.go
@@ -11,8 +11,9 @@ import (
 // (where possible). Required configuration will throw a Fatal error if they
 // are missing.
 type Config struct {
-	Port int    `env:"PORT" envDefault:"5000"`
-	Env  string `env:"HYPERDRIVE_ENVIRONMENT" envDefault:"development"`
+	Port      int    `env:"PORT" envDefault:"5000"`
+	Env       string `env:"HYPERDRIVE_ENV" envDefault:"development"`
+	GzipLevel int    `env:"GZIP_LEVEL" envDefault:"-1"`
 }
 
 // GetPort returns the formatted value of config.Port, for use by the

--- a/config_test.go
+++ b/config_test.go
@@ -28,7 +28,18 @@ func (suite *HyperdriveTestSuite) TestEnvConfigFromDefault() {
 }
 
 func (suite *HyperdriveTestSuite) TestEnvConfigFromEnv() {
-	os.Setenv("HYPERDRIVE_ENVIRONMENT", "test")
+	os.Setenv("HYPERDRIVE_ENV", "test")
 	c := NewConfig()
-	suite.Equal("test", c.Env, "Env should be equal to HYPERDRIVE_ENVIRONMENT value set via ENV var")
+	suite.Equal("test", c.Env, "Env should be equal to HYPERDRIVE_ENV value set via ENV var")
+}
+
+func (suite *HyperdriveTestSuite) TestGzipLevelConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal(-1, c.GzipLevel, "GzipLevel should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestGzipLevelConfigFromEnv() {
+	os.Setenv("GZIP_LEVEL", "9")
+	c := NewConfig()
+	suite.Equal(9, c.GzipLevel, "GzipLevel should be equal to GZIP_LEVEL value set via ENV var")
 }

--- a/middleware.go
+++ b/middleware.go
@@ -10,7 +10,7 @@ import (
 // DefaultMiddlewareChain wraps the given http.Handler in the following chain
 // of middleware: LoggingMiddleware, RecoveryMiddleware.
 func (api *API) DefaultMiddlewareChain(h http.Handler) http.Handler {
-	return api.LoggingMiddleware(api.RecoveryMiddleware(h))
+	return api.CompressionMiddleware(api.LoggingMiddleware(api.RecoveryMiddleware(h)))
 }
 
 // LoggingMiddleware wraps the given http.Handler and outputs requests in Apache-style
@@ -24,4 +24,27 @@ func (api *API) LoggingMiddleware(h http.Handler) http.Handler {
 func (api *API) RecoveryMiddleware(h http.Handler) http.Handler {
 	opt := handlers.PrintRecoveryStack(api.conf.Env != "production")
 	return handlers.RecoveryHandler(opt)(h)
+}
+
+// CompressionMiddleware wraps the given http.Handler and returns a gzipped response if
+// the client requests it with the Accept-Encoding header. The compression level is set
+// to to 1, by default. You can configure this though the
+// GZIP_LEVEL environment variable, and set it to an integer between -2 and 9.
+//
+// Following zlib, levels range from 1 (Best Speed) to 9 (Best Compression); higher
+// levels typically run slower but compress more.
+//
+// -1 is the Default Compression level, and is also used if an invalid value is
+// configured via GZIP_LEVEL.
+//
+// 0 attemps no compression, and only adds the necessary DEFLATE framing.
+//
+// -2 disables Lempel-Ziv match searching and only performs Huffman entropy
+// encoding. This is useful when compressing data that has already been compressed
+// with an LZ style algorithm, such as Snappy or LZ4.
+//
+// More info can be found in the docs for the compress/flate package:
+// https://golang.org/pkg/compress/flate/
+func (api *API) CompressionMiddleware(h http.Handler) http.Handler {
+	return handlers.CompressHandlerLevel(h, api.conf.GzipLevel)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -13,3 +13,7 @@ func (suite *HyperdriveTestSuite) TestLoggingMiddleware() {
 func (suite *HyperdriveTestSuite) TestRecoveryMiddleware() {
 	suite.Implements((*http.Handler)(nil), suite.TestAPI.RecoveryMiddleware(suite.TestHandler), "return an implementation of http.Handler")
 }
+
+func (suite *HyperdriveTestSuite) TestCompressionMiddleware() {
+	suite.Implements((*http.Handler)(nil), suite.TestAPI.CompressionMiddleware(suite.TestHandler), "return an implementation of http.Handler")
+}


### PR DESCRIPTION
- adds `Config.GzipLevel`, which can be set via `GZIP_LEVEL` environment
  variable. It expects a value between `-2` and `9`, with the default being
  `-1`, the zlib default compression level.
- adds `CompressionMiddleware` that will compress the response if
clients request it via `Accept-Encoding` header.

fixes #8