### PR TITLE
adds support for X-HTTP-Method-Override header

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -48,3 +48,10 @@ func (api *API) RecoveryMiddleware(h http.Handler) http.Handler {
 func (api *API) CompressionMiddleware(h http.Handler) http.Handler {
 	return handlers.CompressHandlerLevel(h, api.conf.GzipLevel)
 }
+
+// MethodOverrideMiddleware allows clients who can not perform native PUT, PATCH,
+// or DELETE requests to specify the HTTP method in the X-HTTP-Method-Override
+// header. The header name is case sensitive.
+func (api *API) MethodOverrideMiddleware(h http.Handler) http.Handler {
+	return handlers.HTTPMethodOverrideHandler(h)
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -17,3 +17,7 @@ func (suite *HyperdriveTestSuite) TestRecoveryMiddleware() {
 func (suite *HyperdriveTestSuite) TestCompressionMiddleware() {
 	suite.Implements((*http.Handler)(nil), suite.TestAPI.CompressionMiddleware(suite.TestHandler), "return an implementation of http.Handler")
 }
+
+func (suite *HyperdriveTestSuite) TestMethodOverrideMiddleware() {
+	suite.Implements((*http.Handler)(nil), suite.TestAPI.MethodOverrideMiddleware(suite.TestHandler), "return an implementation of http.Handler")
+}


### PR DESCRIPTION
- switches request method to the one specified in the
`X-HTTP-Method-Override` header, which is useful for dumb clients that
have no native support for `PUT`, `PATCH`, or `DELETE`

fixes #5