### PR TITLE
adds CORS request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ OR
 
 Configuration of core features are done via Environment Variables, in accordence with [12 factor](https://12factor.net/config) principles.
 
-- `HYPERDRIVE_ENV`: (default: `development`, type: `string`) The stage in your deployment pipeline the api is currently running in. A value of `production` changes behviour for some features (such as whether stack traces are logged during panic recovery). Other values, such as `staging`, can be used but currently have no meanin in the framework other than the one you give it in your own code.
-- `PORT` - (default: `5000`, type: `int`) The port the server should listen on.
-- `GZIP_LEVEL` - (default: `-1`, type: `int`) Accepts a value between `-2` and `9`. Invalid values will be silently discarded and the default of `-1` will be used. More info on compression levels can be found in the docs, but corresponds to `zlib` compression levels.
+  - `HYPERDRIVE_ENV`: (default: `development`, type: `string`) The stage in your deployment pipeline the api is currently running in. A value of `production` changes behviour for some features (such as whether stack traces are logged during panic recovery). Other values, such as `staging`, can be used but currently have no meanin in the framework other than the one you give it in your own code.
+  - `PORT`: (default: `5000`, type: `int`) The port the server should listen on.
+  - `GZIP_LEVEL`: (default: `-1`, type: `int`) Accepts a value between `-2` and `9`. Invalid values will be silently discarded and the default of `-1` will be used. More info on compression levels can be found in the docs, but corresponds to `zlib` compression levels.
+  - `CORS_ENABLED`: (default: `true`, type: `bool`) Set this to `false` to disable CORS support.
+  - `CORS_HEADERS`: (default: ``, type: `string`) A comma-seperated list of headers to allow and expose during CORS requests. These will be appended to the default set of headers that are always allowed: `Accept`, `Accept-Language`, `Content-Language`, and `Content-Type`.
+  - `CORS_ORIGINS`: (default: `*`, type: `string`) A comma-seperated list of origins to allow during CORS requests. These will replace the default value, which is to allow all origins.
+  - `CORS_CREDENTIALS`: (default: `true`, type: `bool`) Set this to `false` to disable authenticated CORS requests.
 
 ## Docs
 

--- a/config.go
+++ b/config.go
@@ -11,9 +11,13 @@ import (
 // (where possible). Required configuration will throw a Fatal error if they
 // are missing.
 type Config struct {
-	Port      int    `env:"PORT" envDefault:"5000"`
-	Env       string `env:"HYPERDRIVE_ENV" envDefault:"development"`
-	GzipLevel int    `env:"GZIP_LEVEL" envDefault:"-1"`
+	Port            int    `env:"PORT" envDefault:"5000"`
+	Env             string `env:"HYPERDRIVE_ENV" envDefault:"development"`
+	GzipLevel       int    `env:"GZIP_LEVEL" envDefault:"-1"`
+	CorsEnabled     bool   `env:"CORS_ENABLED" envDefault:"true"`
+	CorsOrigins     string `env:"CORS_ORIGINS" envDefault:"*"`
+	CorsHeaders     string `env:"CORS_HEADERS" envDefault:""`
+	CorsCredentials bool   `env:"CORS_CREDENTIALS" envDefault:"true"`
 }
 
 // GetPort returns the formatted value of config.Port, for use by the

--- a/config_test.go
+++ b/config_test.go
@@ -43,3 +43,47 @@ func (suite *HyperdriveTestSuite) TestGzipLevelConfigFromEnv() {
 	c := NewConfig()
 	suite.Equal(9, c.GzipLevel, "GzipLevel should be equal to GZIP_LEVEL value set via ENV var")
 }
+
+func (suite *HyperdriveTestSuite) TestCorsEnabledConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal(true, c.CorsEnabled, "CorsEnabled should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsEnabledConfigFromEnv() {
+	os.Setenv("CORS_ENABLED", "false")
+	c := NewConfig()
+	suite.Equal(false, c.CorsEnabled, "CorsEnabled should be equal to CORS_ENABLED value set via ENV var")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsOriginsConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal("*", c.CorsOrigins, "CorsOrigins should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsOriginsConfigFromEnv() {
+	os.Setenv("CORS_ORIGINS", "example.com")
+	c := NewConfig()
+	suite.Equal("example.com", c.CorsOrigins, "CorsOrigins should be equal to CORS_ORIGINS value set via ENV var")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsHeadersConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal("", c.CorsHeaders, "CorsHeaders should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsHeadersConfigFromEnv() {
+	os.Setenv("CORS_HEADERS", "example.com")
+	c := NewConfig()
+	suite.Equal("example.com", c.CorsHeaders, "CorsHeaders should be equal to CORS_HEADERS value set via ENV var")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsCredentialsConfigFromDefault() {
+	c := NewConfig()
+	suite.Equal(true, c.CorsCredentials, "CorsCredentials should be equal to default value")
+}
+
+func (suite *HyperdriveTestSuite) TestCorsCredentialsConfigFromEnv() {
+	os.Setenv("CORS_CREDENTIALS", "false")
+	c := NewConfig()
+	suite.Equal(false, c.CorsCredentials, "CorsCredentials should be equal to CORS_CREDENTIALS value set via ENV var")
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -21,3 +21,7 @@ func (suite *HyperdriveTestSuite) TestCompressionMiddleware() {
 func (suite *HyperdriveTestSuite) TestMethodOverrideMiddleware() {
 	suite.Implements((*http.Handler)(nil), suite.TestAPI.MethodOverrideMiddleware(suite.TestHandler), "return an implementation of http.Handler")
 }
+
+func (suite *HyperdriveTestSuite) TestCorsMiddleware() {
+	suite.Implements((*http.Handler)(nil), suite.TestAPI.CorsMiddleware(suite.TestHandler), "return an implementation of http.Handler")
+}


### PR DESCRIPTION
- enabled by default, this middleware will handle CORS requests from all origins.
- configured via environment variables: `CORS_ENABLED`, `CORS_ORIGINS`,`CORS_HEADERS`, `CORS_CREDENTIALS`

fixes #4