### PR TITLE
adds Endpoint Verison

### DIFF
--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -16,6 +16,10 @@ func (suite *HyperdriveTestSuite) TestGetPath() {
 	suite.Equal("/test", suite.TestEndpoint.GetPath(), "expects GetPath() to return Path")
 }
 
+func (suite *HyperdriveTestSuite) TestGetVersion() {
+	suite.Equal("v1.0.1", suite.TestEndpoint.GetVersion(), "expects GetVersion() to return Version")
+}
+
 func (suite *HyperdriveTestSuite) TestEndpointer() {
 	suite.Implements((*Endpointer)(nil), suite.TestEndpoint, "expects an implementation of hyperdrive.Endpointer interface")
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 508e9b0af06800b503a5a78fd5830652f290132373e8e00ad0dbf736c04d3dcc
-updated: 2017-03-04T17:36:31.02597264-06:00
+hash: 7bf3b501233a2729c72609562a733518952e95ed73780b2bb20d56c2e7b60d89
+updated: 2017-03-10T17:45:56.469489343-06:00
 imports:
 - name: github.com/caarlos0/env
   version: d0de832ed2fbc4e7bfaa30ab5cf0b3417d15f529
@@ -9,9 +9,11 @@ imports:
   version: 3a5767ca75ece5f7f1440b1d16975247f8d8b221
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,8 @@ import:
   version: ^1.2.0
 - package: github.com/caarlos0/env
   version: ^2.1.0
+- package: github.com/Masterminds/semver
+  version: 1.2.2
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -19,7 +19,7 @@ type HyperdriveTestSuite struct {
 
 func (suite *HyperdriveTestSuite) SetupTest() {
 	suite.TestAPI = NewAPI("Test API", "Test API Desc")
-	suite.TestEndpoint = NewEndpoint("Test", "Test Endpoint", "/test")
+	suite.TestEndpoint = NewEndpoint("Test", "Test Endpoint", "/test", "1.0.1")
 	suite.TestHandler = NewMethodHandler(suite.TestEndpoint)
 	suite.TestRoot = NewRootResource(suite.TestAPI)
 	suite.TestEndpointRepresentation = Representation{"name": "Test", "desc": "Test Endpoint", "path": "/test", "methods": []string{"OPTIONS"}}


### PR DESCRIPTION
- uses `semver` in the default implementation, to give it some structure, but produces a clean version (e.g. `v1` from `1.0.0`) for use in media types (see #21)
- users of the package can override this by producing any string they want in an `Endpointer`'s `GetVersion()` method

fixes #2