### PR TITLE
supports X-Content-Type-Options, X-Frame-Options

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -25,3 +25,11 @@ func (suite *HyperdriveTestSuite) TestMethodOverrideMiddleware() {
 func (suite *HyperdriveTestSuite) TestCorsMiddleware() {
 	suite.Implements((*http.Handler)(nil), suite.TestAPI.CorsMiddleware(suite.TestHandler), "return an implementation of http.Handler")
 }
+
+func (suite *HyperdriveTestSuite) TestContentTypeOptionsMiddleware() {
+	suite.Implements((*http.Handler)(nil), suite.TestAPI.ContentTypeOptionsMiddleware(suite.TestHandler), "return an implementation of http.Handler")
+}
+
+func (suite *HyperdriveTestSuite) TestFrameOptionsMiddleware() {
+	suite.Implements((*http.Handler)(nil), suite.TestAPI.FrameOptionsMiddleware(suite.TestHandler), "return an implementation of http.Handler")
+}


### PR DESCRIPTION
- automatically adds `X-Content-Type-Options` header with value of
`nosniff` to response
- automatically adds `X-Frame-Options` header with value of
`DENY` to response

fixes #23, #24