### PR TITLE
implements automatic Content Negotiation

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,12 @@ import (
 	"github.com/caarlos0/env"
 )
 
+var conf Config
+
+func init() {
+	conf = NewConfig()
+}
+
 // Config holds configuration values from the environment, with sane defaults
 // (where possible). Required configuration will throw a Fatal error if they
 // are missing.

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -11,23 +11,10 @@ func (suite *HyperdriveTestSuite) TestRootResourceEndpointsEmpty() {
 }
 
 func (suite *HyperdriveTestSuite) TestAddEndpointer() {
-	suite.TestRoot.AddEndpointer(suite.TestEndpoint)
+	suite.TestRoot.AddEndpoint(suite.TestEndpoint)
 	suite.Equal(1, len(suite.TestRoot.Endpoints), "expects 1 Endpoints")
 }
 
 func (suite *HyperdriveTestSuite) TestRootResourceServeHTTP() {
 	suite.Implements((*http.Handler)(nil), suite.TestRoot, "return an implementation of http.Handler")
-}
-
-func (suite *HyperdriveTestSuite) TestPresentRepresentation() {
-	suite.IsType(Representation{}, suite.TestRoot.Present(), "return a Representation")
-}
-
-func (suite *HyperdriveTestSuite) TestPresent() {
-	suite.TestRoot.AddEndpointer(suite.TestEndpoint)
-	suite.Equal(suite.TestRootRepresentation, suite.TestRoot.Present(), "return the correct Representation of RootResource")
-}
-
-func (suite *HyperdriveTestSuite) TestPresentEndpoint() {
-	suite.Equal(suite.TestEndpointRepresentation, PresentEndpoint(suite.TestEndpoint), "return the correct Representation of RootResource")
 }

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,63 @@
+package hyperdrive
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// ContentEncoder interface wraps the details of encoding response bodies to
+// support automatic Content Negotiation.
+type ContentEncoder interface {
+	Encode(interface{}) error
+}
+
+// NullEncoder is an implementation of ContentEncoder, and is the default
+// encoder used when Content Negotiation has falied. It produces a 406
+// NOT ACCEPTABLE error when it's Encode() function is run.
+type NullEncoder struct{}
+
+// Encode returns a 406 NOT ACCEPTABLE error.
+func (enc NullEncoder) Encode(v interface{}) error {
+	return errors.New(http.StatusText(http.StatusNotAcceptable))
+}
+
+// JSONEncoder is an implementation of ContentEncoder and wraps the Encoder
+// found in encoding/json package.
+type JSONEncoder struct {
+	Encoder *json.Encoder
+}
+
+// Encode encodes input as json text or returns an error.
+func (enc JSONEncoder) Encode(v interface{}) error {
+	return enc.Encoder.Encode(v)
+}
+
+// XMLEncoder is an implementation of ContentEncoder and wraps the Encoder
+// found in encoding/xml package.
+type XMLEncoder struct {
+	Encoder *xml.Encoder
+}
+
+// Encode encodes input as xml text or returns an error.
+func (enc XMLEncoder) Encode(v interface{}) error {
+	return enc.Encoder.Encode(v)
+}
+
+// GetEncoder returns the correct ContentEncoder, determined by the Accept
+// header, to support automatic Content Negotiation.
+func GetEncoder(rw http.ResponseWriter, accept string) (ContentEncoder, http.ResponseWriter) {
+	if strings.HasSuffix(accept, "json") {
+		rw.Header().Set("Content-Type", accept)
+		return JSONEncoder{json.NewEncoder(rw)}, rw
+	}
+
+	if strings.HasSuffix(accept, "xml") {
+		rw.Header().Set("Content-Type", accept)
+		return XMLEncoder{xml.NewEncoder(rw)}, rw
+	}
+
+	return NullEncoder{}, rw
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,71 @@
+package hyperdrive
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http/httptest"
+)
+
+func (suite *HyperdriveTestSuite) TestNullEncoder() {
+	suite.Implements((*ContentEncoder)(nil), NullEncoder{}, "return an implementation of ContentEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestNullEncoderEncode() {
+	suite.Error(NullEncoder{}.Encode(suite.TestEndpointResource), "return an error")
+}
+
+func (suite *HyperdriveTestSuite) TestJSONEncoder() {
+	suite.Implements((*ContentEncoder)(nil), JSONEncoder{}, "return an implementation of ContentEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestJSONEncoderEncodeNoError() {
+	rw := httptest.NewRecorder()
+	enc := JSONEncoder{Encoder: json.NewEncoder(rw)}
+	suite.Nil(enc.Encode(suite.TestEndpointResource), "returns nil")
+}
+
+func (suite *HyperdriveTestSuite) TestJSONEncoderEncode() {
+	rw := httptest.NewRecorder()
+	enc := JSONEncoder{Encoder: json.NewEncoder(rw)}
+	enc.Encode(suite.TestEndpointResource)
+	json := `{"resource":"endpoint","name":"Test","path":"/test","methods":["OPTIONS"],"description":"Test Endpoint"}` + "\n"
+	suite.Equal(json, rw.Body.String(), "returns nil")
+}
+
+func (suite *HyperdriveTestSuite) TestXMLEncoder() {
+	suite.Implements((*ContentEncoder)(nil), XMLEncoder{}, "return an implementation of ContentEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestXMLEncoderEncodeNoError() {
+	rw := httptest.NewRecorder()
+	enc := XMLEncoder{Encoder: xml.NewEncoder(rw)}
+	suite.Nil(enc.Encode(suite.TestEndpointResource), "returns nil")
+}
+
+func (suite *HyperdriveTestSuite) TestXMLEncoderEncode() {
+	rw := httptest.NewRecorder()
+	enc := XMLEncoder{Encoder: xml.NewEncoder(rw)}
+	enc.Encode(suite.TestEndpointResource)
+	xml := `<endpoint name="Test" path="/test" methods="OPTIONS"><description>Test Endpoint</description></endpoint>`
+	suite.Equal(xml, rw.Body.String(), "returns nil")
+}
+
+func (suite *HyperdriveTestSuite) TestGetEncoder() {
+	enc, _ := GetEncoder(httptest.NewRecorder(), "text/plain")
+	suite.Implements((*ContentEncoder)(nil), enc, "return an implementation of ContentEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestGetEncoderXML() {
+	enc, _ := GetEncoder(httptest.NewRecorder(), "application/xml")
+	suite.IsType(XMLEncoder{}, enc, "return an XMLEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestGetEncoderJSON() {
+	enc, _ := GetEncoder(httptest.NewRecorder(), "application/json")
+	suite.IsType(JSONEncoder{}, enc, "return a JSONEncoder")
+}
+
+func (suite *HyperdriveTestSuite) TestGetEncoderNULL() {
+	enc, _ := GetEncoder(httptest.NewRecorder(), "text/plain")
+	suite.IsType(NullEncoder{}, enc, "return a NullEncoder")
+}

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,5 +1,7 @@
 package hyperdrive
 
+import "net/http"
+
 func (suite *HyperdriveTestSuite) TestNewEndpoint() {
 	suite.IsType(&Endpoint{}, suite.TestEndpoint, "expects an instance of hyperdrive.Endpoint")
 }
@@ -30,4 +32,8 @@ func (suite *HyperdriveTestSuite) TestGetMethods() {
 
 func (suite *HyperdriveTestSuite) TestGetMethodsList() {
 	suite.Equal("OPTIONS", GetMethodsList(suite.TestEndpoint), "expects a list of supported method strings")
+}
+
+func (suite *HyperdriveTestSuite) TestNewMethodHandler() {
+	suite.Implements((*http.Handler)(nil), NewMethodHandler(suite.TestEndpoint), "return an implementation of http.Handler")
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,14 @@
+package hyperdrive
+
+import "net/http"
+
+// GetErrorText helps ensure implementation details are not leaked in production
+// environments. If this is production, it returns the http.StatusText for the
+// given status code. If this is not production, the error message is returned
+// to aid in debugging.
+func GetErrorText(status int, err error) string {
+	if conf.Env != "production" {
+		return err.Error()
+	}
+	return http.StatusText(status)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,15 @@
+package hyperdrive
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (suite *HyperdriveTestSuite) TestGetErrorTextProduction() {
+	conf.Env = "production"
+	suite.Equal(http.StatusText(406), GetErrorText(406, errors.New("Test Error")), "returns 406 Status Text")
+}
+
+func (suite *HyperdriveTestSuite) TestGetErrorText() {
+	suite.Equal("Test Error", GetErrorText(406, errors.New("Test Error")), "returns Error Text")
+}

--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -19,7 +19,6 @@ type API struct {
 	Router    *mux.Router
 	Server    *http.Server
 	Root      *RootResource
-	conf      Config
 	endpoints []Endpoint
 }
 
@@ -29,13 +28,12 @@ func NewAPI(name string, desc string) API {
 		Name:   name,
 		Desc:   desc,
 		Router: mux.NewRouter(),
-		conf:   NewConfig(),
 	}
 	api.Root = NewRootResource(api)
 	api.Router.Handle("/", api.DefaultMiddlewareChain(api.Root)).Methods("GET")
 	api.Server = &http.Server{
 		Handler:      api.Router,
-		Addr:         api.conf.GetPort(),
+		Addr:         conf.GetPort(),
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
@@ -46,7 +44,7 @@ func NewAPI(name string, desc string) API {
 // respond with a 405 error if the endpoint does not support a particular
 // HTTP method.
 func (api *API) AddEndpoint(e Endpointer) {
-	api.Root.AddEndpointer(e)
+	api.Root.AddEndpoint(e)
 	api.Router.Handle(e.GetPath(), api.DefaultMiddlewareChain(NewMethodHandler(e)))
 }
 
@@ -63,7 +61,7 @@ func (api *API) GetMediaType(e Endpointer) string {
 // Start starts the configured http server, listening on the configured Port
 // (default: 5000). Set the PORT environment variable to change this.
 func (api *API) Start() {
-	log.Printf("Hyperdrive API starting on PORT %d in ENVIRONMENT %s", api.conf.Port, api.conf.Env)
+	log.Printf("Hyperdriven API: %s starting on: http://0.0.0.0:%d in: %s", api.Name, conf.Port, conf.Env)
 	log.Fatal(api.Server.ListenAndServe())
 }
 

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -9,12 +9,11 @@ import (
 
 type HyperdriveTestSuite struct {
 	suite.Suite
-	TestAPI                    API
-	TestEndpoint               Endpointer
-	TestHandler                http.Handler
-	TestRoot                   *RootResource
-	TestRootRepresentation     Representation
-	TestEndpointRepresentation Representation
+	TestAPI              API
+	TestEndpoint         Endpointer
+	TestHandler          http.Handler
+	TestRoot             *RootResource
+	TestEndpointResource EndpointResource
 }
 
 func (suite *HyperdriveTestSuite) SetupTest() {
@@ -22,8 +21,7 @@ func (suite *HyperdriveTestSuite) SetupTest() {
 	suite.TestEndpoint = NewEndpoint("Test", "Test Endpoint", "/test", "1.0.1")
 	suite.TestHandler = NewMethodHandler(suite.TestEndpoint)
 	suite.TestRoot = NewRootResource(suite.TestAPI)
-	suite.TestEndpointRepresentation = Representation{"name": "Test", "desc": "Test Endpoint", "path": "/test", "methods": []string{"OPTIONS"}}
-	suite.TestRootRepresentation = Representation{"resource": "api", "name": "API", "endpoints": []Representation{suite.TestEndpointRepresentation}}
+	suite.TestEndpointResource = NewEndpointResource(suite.TestEndpoint)
 }
 
 func (suite *HyperdriveTestSuite) TestNewAPI() {

--- a/middleware.go
+++ b/middleware.go
@@ -25,7 +25,7 @@ func (api *API) LoggingMiddleware(h http.Handler) http.Handler {
 // RecoveryMiddleware wraps the given http.Handler and recovers from panics. It wil log
 // the stacktrace if HYPERDRIVE_ENVIRONMENT env var is not set to "production".
 func (api *API) RecoveryMiddleware(h http.Handler) http.Handler {
-	opt := handlers.PrintRecoveryStack(api.conf.Env != "production")
+	opt := handlers.PrintRecoveryStack(conf.Env != "production")
 	return handlers.RecoveryHandler(opt)(h)
 }
 
@@ -49,7 +49,7 @@ func (api *API) RecoveryMiddleware(h http.Handler) http.Handler {
 // More info can be found in the docs for the compress/flate package:
 // https://golang.org/pkg/compress/flate/
 func (api *API) CompressionMiddleware(h http.Handler) http.Handler {
-	return handlers.CompressHandlerLevel(h, api.conf.GzipLevel)
+	return handlers.CompressHandlerLevel(h, conf.GzipLevel)
 }
 
 // MethodOverrideMiddleware allows clients who can not perform native PUT, PATCH,
@@ -67,13 +67,13 @@ func (api *API) MethodOverrideMiddleware(h http.Handler) http.Handler {
 // - CORS_HEADERS (string)
 // - CORS_CREDENTIALS (bool)
 func (api *API) CorsMiddleware(h http.Handler) http.Handler {
-	if api.conf.CorsEnabled == true {
+	if conf.CorsEnabled == true {
 		return h
 	}
 	defaultHeaders := []string{"Content-Type", "X-Content-Type-Options"}
-	headers := handlers.AllowedHeaders(append(defaultHeaders, strings.Split(api.conf.CorsHeaders, ",")...))
-	origins := handlers.AllowedOrigins(strings.Split(api.conf.CorsOrigins, ","))
-	if api.conf.CorsCredentials == true {
+	headers := handlers.AllowedHeaders(append(defaultHeaders, strings.Split(conf.CorsHeaders, ",")...))
+	origins := handlers.AllowedOrigins(strings.Split(conf.CorsOrigins, ","))
+	if conf.CorsCredentials == true {
 		handlers.AllowCredentials()
 	}
 	return handlers.CORS(headers, origins)(h)


### PR DESCRIPTION
- adds `Respond()` helper function to be used in Endpoint method handlers
- `Respond()` takes an http.ResponseWriter, http.Request, and user supplied: status, body, and 0 or more `http.Header`s
- if value of `Accept` header ends in `json`, `body` will be encoded as json
- if value of `Accept` header ends in `xml`, `body` will be encoded as xml
- switches `Present()`, `Representation` and friends to just using struct tags to aid in encoding `RootResource` in xml/json
- adds `EndpointResource` to replace the old `Representation`

fixes #17