### PR TITLE
clean up media types

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -24,13 +24,15 @@ type RootResource struct {
 // the hypermedia respresentation returned by the Discovery URL endpoint for
 // API clients to learn about the Endpoint.
 type EndpointResource struct {
-	XMLName     xml.Name `json:"-" xml:"endpoint"`
-	Resource    string   `json:"resource" xml:"-"`
-	Name        string   `json:"name" xml:"name,attr"`
-	Path        string   `json:"path" xml:"path,attr"`
-	MethodsList string   `json:"-" xml:"methods,attr"`
-	Methods     []string `json:"methods" xml:"-"`
-	Desc        string   `json:"description" xml:"description"`
+	XMLName        xml.Name `json:"-" xml:"endpoint"`
+	Resource       string   `json:"resource" xml:"-"`
+	Name           string   `json:"name" xml:"name,attr"`
+	Path           string   `json:"path" xml:"path,attr"`
+	MethodsList    string   `json:"-" xml:"methods,attr"`
+	Methods        []string `json:"methods" xml:"-"`
+	MediaTypesList string   `json:"-" xml:"media-types,attr"`
+	MediaTypes     []string `json:"media-types" xml:"-"`
+	Desc           string   `json:"description" xml:"description"`
 }
 
 // NewRootResource creates an instance of RootResource from the given API.
@@ -40,7 +42,16 @@ func NewRootResource(api API) *RootResource {
 
 // NewEndpointResource creates an instance of EndpointResource from the given Endpointer.
 func NewEndpointResource(e Endpointer) EndpointResource {
-	return EndpointResource{Resource: "endpoint", Name: e.GetName(), Path: e.GetPath(), MethodsList: GetMethodsList(e), Methods: GetMethods(e), Desc: e.GetDesc()}
+	return EndpointResource{
+		Resource:       "endpoint",
+		Name:           e.GetName(),
+		Path:           e.GetPath(),
+		MethodsList:    GetMethodsList(e),
+		Methods:        GetMethods(e),
+		MediaTypesList: GetContentTypesList(hAPI, e),
+		MediaTypes:     GetContentTypes(hAPI, e),
+		Desc:           e.GetDesc(),
+	}
 }
 
 // AddEndpoint adds EndpointResources to the slice of Endpoints on an instance of RootResource.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -28,7 +28,7 @@ func (suite *HyperdriveTestSuite) TestJSONEncoderEncode() {
 	rw := httptest.NewRecorder()
 	enc := JSONEncoder{Encoder: json.NewEncoder(rw)}
 	enc.Encode(suite.TestEndpointResource)
-	json := `{"resource":"endpoint","name":"Test","path":"/test","methods":["OPTIONS"],"description":"Test Endpoint"}` + "\n"
+	json := `{"resource":"endpoint","name":"Test","path":"/test","methods":["OPTIONS"],"media-types":["application/vnd.api.test.v1.0.1.json","application/vnd.api.test.v1.0.1.xml"],"description":"Test Endpoint"}` + "\n"
 	suite.Equal(json, rw.Body.String(), "returns nil")
 }
 
@@ -46,7 +46,7 @@ func (suite *HyperdriveTestSuite) TestXMLEncoderEncode() {
 	rw := httptest.NewRecorder()
 	enc := XMLEncoder{Encoder: xml.NewEncoder(rw)}
 	enc.Encode(suite.TestEndpointResource)
-	xml := `<endpoint name="Test" path="/test" methods="OPTIONS"><description>Test Endpoint</description></endpoint>`
+	xml := `<endpoint name="Test" path="/test" methods="OPTIONS" media-types="application/vnd.api.test.v1.0.1.json,application/vnd.api.test.v1.0.1.xml"><description>Test Endpoint</description></endpoint>`
 	suite.Equal(xml, rw.Body.String(), "returns nil")
 }
 

--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -1,7 +1,6 @@
 package hyperdrive
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -9,6 +8,10 @@ import (
 
 	"github.com/gorilla/mux"
 	slugify "github.com/metal3d/go-slugify"
+)
+
+var (
+	hAPI API
 )
 
 // API is a logical collection of one or more endpoints, connecting requests
@@ -37,6 +40,7 @@ func NewAPI(name string, desc string) API {
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
+	hAPI = api
 	return api
 }
 
@@ -46,45 +50,18 @@ func NewAPI(name string, desc string) API {
 func (api *API) AddEndpoint(e Endpointer) {
 	api.Root.AddEndpoint(e)
 	api.Router.Handle(e.GetPath(), api.DefaultMiddlewareChain(NewMethodHandler(e))).
-		Headers("Accept", api.GetContentTypeJSON(e)).
-		Headers("Accet", api.GetContentTypeXML(e))
-}
+		Headers("Accept", GetContentTypeJSON(*api, e)).
+		Headers("Accet", GetContentTypeXML(*api, e))
+	log.Printf("Added hyperdriven Endpoint: %s http://0.0.0.0:%d%s", e.GetName(), conf.Port, e.GetPath())
+	log.Printf("    Methods: %s", GetMethodsList(e))
+	log.Printf("    Media Types: %s", GetContentTypesList(*api, e))
 
-// GetMediaType returns a media type string, sans any content-type extension (e.g. json),
-// based on the name of the API, the Endpoint, and the Endpoint's version. The Media Type
-// produced will be used for Content Negotiation, via the Accept header, as well as routing
-// to the appropriate endpoint, when the media type appears in the request headers (e.g.
-// Accept and Content-Type). It will also be used, after content negotation in the
-// Content-Type response header.
-func (api *API) GetMediaType(e Endpointer) string {
-	return fmt.Sprintf("application/vnd.%s.%s.%s", slug(api.Name), slug(e.GetName()), e.GetVersion())
-}
-
-// GetContentTypeJSON returns the json Content-Type an endpoint can accept and
-// respond with. The Content-Type will include the versioned vendor Media
-// Type returned by API.GetMediaType() with a json extension.
-func (api *API) GetContentTypeJSON(e Endpointer) string {
-	return fmt.Sprintf("%s.json", api.GetMediaType(e))
-}
-
-// GetContentTypeXML returns the xml Content-Type an endpoint can accept and
-// respond with. The Content-Type will include the versioned vendor Media
-// Type returned by API.GetMediaType() with an xml extension.
-func (api *API) GetContentTypeXML(e Endpointer) string {
-	return fmt.Sprintf("%s.xml", api.GetMediaType(e))
-}
-
-// GetContentTypes returns a slice of Content-Types the endpoint can accept and
-// respond with. The Content-Types will include both the versioned vendor Media
-// Type returned by API.GetMediaType() for both json and xml.
-func (api *API) GetContentTypes(e Endpointer) []string {
-	return []string{api.GetContentTypeJSON(e), api.GetContentTypeXML(e)}
 }
 
 // Start starts the configured http server, listening on the configured Port
 // (default: 5000). Set the PORT environment variable to change this.
 func (api *API) Start() {
-	log.Printf("Hyperdriven API: %s starting on: http://0.0.0.0:%d in: %s", api.Name, conf.Port, conf.Env)
+	log.Printf("Starting hyperdriven API (%s): %s http://0.0.0.0:%d", conf.Env, api.Name, conf.Port)
 	log.Fatal(api.Server.ListenAndServe())
 }
 

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -32,10 +32,6 @@ func (suite *HyperdriveTestSuite) TestAPIServer() {
 	suite.IsType(&http.Server{}, suite.TestAPI.Server, "expects an instance of *http.Server")
 }
 
-func (suite *HyperdriveTestSuite) TestGetMediaType() {
-	suite.Equal("application/vnd.api.test.v1.0.1", suite.TestAPI.GetMediaType(suite.TestEndpoint), "returns a media type string")
-}
-
 func TestHyperdriveTestSuite(t *testing.T) {
 	suite.Run(t, new(HyperdriveTestSuite))
 }

--- a/mediatype.go
+++ b/mediatype.go
@@ -1,0 +1,44 @@
+package hyperdrive
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetMediaType returns a media type string, sans any content-type extension (e.g. json),
+// based on the name of the API, the Endpoint, and the Endpoint's version. The Media Type
+// produced will be used for Content Negotiation, via the Accept header, as well as routing
+// to the appropriate endpoint, when the media type appears in the request headers (e.g.
+// Accept and Content-Type). It will also be used, after content negotation in the
+// Content-Type response header.
+func GetMediaType(api API, e Endpointer) string {
+	return fmt.Sprintf("application/vnd.%s.%s.%s", slug(api.Name), slug(e.GetName()), e.GetVersion())
+}
+
+// GetContentTypeJSON returns the json Content-Type an endpoint can accept and
+// respond with. The Content-Type will include the versioned vendor Media
+// Type returned by API.GetMediaType() with a json extension.
+func GetContentTypeJSON(api API, e Endpointer) string {
+	return fmt.Sprintf("%s.json", GetMediaType(api, e))
+}
+
+// GetContentTypeXML returns the xml Content-Type an endpoint can accept and
+// respond with. The Content-Type will include the versioned vendor Media
+// Type returned by API.GetMediaType() with an xml extension.
+func GetContentTypeXML(api API, e Endpointer) string {
+	return fmt.Sprintf("%s.xml", GetMediaType(api, e))
+}
+
+// GetContentTypes returns a slice of Content-Types that the endpoint can accept
+// and respond with. The Content-Types will include both the versioned vendor
+// Media Type returned by API.GetMediaType() for both json and xml.
+func GetContentTypes(api API, e Endpointer) []string {
+	return []string{GetContentTypeJSON(api, e), GetContentTypeXML(api, e)}
+}
+
+// GetContentTypesList returns a list of Content-Type strings that the endpoint can
+// accept and respond with. The Content-Types will include both the versioned
+// vendor Media Type returned by API.GetMediaType() for both json and xml.
+func GetContentTypesList(api API, e Endpointer) string {
+	return strings.Join(GetContentTypes(api, e), ",")
+}

--- a/mediatype_test.go
+++ b/mediatype_test.go
@@ -1,0 +1,21 @@
+package hyperdrive
+
+func (suite *HyperdriveTestSuite) TestGetMediaType() {
+	suite.Equal("application/vnd.api.test.v1.0.1", GetMediaType(suite.TestAPI, suite.TestEndpoint), "returns a media type string")
+}
+
+func (suite *HyperdriveTestSuite) TestGetContentTypeJSON() {
+	suite.Equal("application/vnd.api.test.v1.0.1.json", GetContentTypeJSON(suite.TestAPI, suite.TestEndpoint), "returns a media type string")
+}
+
+func (suite *HyperdriveTestSuite) TestGetContentTypeXML() {
+	suite.Equal("application/vnd.api.test.v1.0.1.xml", GetContentTypeXML(suite.TestAPI, suite.TestEndpoint), "returns a media type string")
+}
+
+func (suite *HyperdriveTestSuite) TestGetContentTypes() {
+	suite.Equal([]string{"application/vnd.api.test.v1.0.1.json", "application/vnd.api.test.v1.0.1.xml"}, GetContentTypes(suite.TestAPI, suite.TestEndpoint), "returns a media type string")
+}
+
+func (suite *HyperdriveTestSuite) TestGetContentTypesList() {
+	suite.Equal("application/vnd.api.test.v1.0.1.json,application/vnd.api.test.v1.0.1.xml", GetContentTypesList(suite.TestAPI, suite.TestEndpoint), "returns a media type string")
+}


### PR DESCRIPTION
- adds media types to discovery URL
- logs info about endpoints after they're added to the api (including
methods and media types)
- adds global `hAPI` to make it easier to reference the api instance
around the codebase (unexported)

fixes #30