### PR TITLE
adds `param` struct tag

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 74a8b2717375531d919d594c0868c2490810ffb111600bb28124e4880e9164c5
-updated: 2017-03-10T18:37:33.280466765-06:00
+hash: e402503411faae1d2a4013574093ed6bead247cea2ad860d966c8511004d0d9f
+updated: 2017-03-20T15:54:53.297458528-05:00
 imports:
 - name: github.com/caarlos0/env
   version: d0de832ed2fbc4e7bfaa30ab5cf0b3417d15f529
@@ -13,9 +13,11 @@ imports:
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/metal3d/go-slugify
   version: 7ac2014b2f23e254684c08d597496681d12c6a8a
+- name: github.com/xtgo/set
+  version: 4431f6b51265b1e0b76af4dafc09d6f12c2bdcd0
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,7 @@ import:
 - package: github.com/Masterminds/semver
   version: 1.2.2
 - package: github.com/metal3d/go-slugify
+- package: github.com/xtgo/set
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -9,15 +9,29 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+type TaggedStruct struct {
+	*Endpoint
+	TestParam         string `param:"test_param;a=GET,PUT;r=PUT"`
+	TestParamDefault  string `param:"test_param_default"`
+	TestParamEmpty    string `param:""`
+	TestParamRequired string `param:"test_param_required;a=GET;r=PUT"`
+}
+
 type HyperdriveTestSuite struct {
 	suite.Suite
-	TestAPI              API
-	TestEndpoint         Endpointer
-	TestHandler          http.Handler
-	TestRoot             *RootResource
-	TestEndpointResource EndpointResource
-	TestGetRequest       *http.Request
-	TestPostRequest      *http.Request
+	TestAPI                 API
+	TestEndpoint            Endpointer
+	TestHandler             http.Handler
+	TestRoot                *RootResource
+	TestEndpointResource    EndpointResource
+	TestGetRequest          *http.Request
+	TestPostRequest         *http.Request
+	TestParsedParam         parsedParam
+	TestParsedParamDefault  parsedParam
+	TestParsedParamEmpty    parsedParam
+	TestParsedParamRequired parsedParam
+	TestTaggedStruct        TaggedStruct
+	TestParsedParamMap      map[string]parsedParam
 }
 
 func (suite *HyperdriveTestSuite) SetupTest() {
@@ -28,6 +42,12 @@ func (suite *HyperdriveTestSuite) SetupTest() {
 	suite.TestEndpointResource = NewEndpointResource(suite.TestEndpoint)
 	suite.TestGetRequest = httptest.NewRequest("GET", "/test/2?id=1&a=b", nil)
 	suite.TestPostRequest = httptest.NewRequest("POST", "/test/2?id=1&a=b", strings.NewReader(`{"id":3}`))
+	suite.TestParsedParam = parsedParam{"TestParam", "string", "test_param", []string{"GET", "PUT"}, []string{"PUT"}}
+	suite.TestParsedParamDefault = parsedParam{"TestParamDefault", "string", "test_param_default", []string{"GET", "PATCH", "POST", "PUT"}, []string{}}
+	suite.TestParsedParamEmpty = parsedParam{"TestParamEmpty", "string", "TestParamEmpty", []string{"GET", "PATCH", "POST", "PUT"}, []string{}}
+	suite.TestParsedParamRequired = parsedParam{"TestParamRequired", "string", "test_param_required", []string{"GET", "PUT"}, []string{"PUT"}}
+	suite.TestParsedParamMap = map[string]parsedParam{"test_param": suite.TestParsedParam, "test_param_default": suite.TestParsedParamDefault, "TestParamEmpty": suite.TestParsedParamEmpty, "test_param_required": suite.TestParsedParamRequired}
+	suite.TestTaggedStruct = TaggedStruct{}
 }
 
 func (suite *HyperdriveTestSuite) TestNewAPI() {

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,90 @@
+package hyperdrive
+
+import (
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/xtgo/set"
+)
+
+const (
+	tagName = "param"
+)
+
+type parsedParam struct {
+	Field    string
+	Type     string
+	Key      string
+	Allowed  []string
+	Required []string
+}
+
+func (p parsedParam) IsAllowed(method string) bool {
+	return contains(p.Allowed, method)
+}
+
+func (p parsedParam) IsRequired(method string) bool {
+	return contains(p.Required, method)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, m := range haystack {
+		if m == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func parse(e Endpointer) map[string]parsedParam {
+	var params = map[string]parsedParam{}
+	t := reflect.TypeOf(e)
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if _, ok := field.Tag.Lookup(tagName); ok {
+			parsed := parseField(field)
+			params[parsed.Key] = parsed
+		}
+	}
+	return params
+}
+
+func parseField(field reflect.StructField) parsedParam {
+	var (
+		key      string
+		tags     []string
+		allowed  = []string{"GET", "POST", "PUT", "PATCH"}
+		required = []string{}
+	)
+	t := field.Tag.Get(tagName)
+	tags = strings.Split(t, ";")
+	key, tags = tags[0], tags[1:]
+	if key == "" {
+		key = field.Name
+	}
+
+	for _, tag := range tags {
+		pairs := strings.Split(tag, "=")
+		k, v := pairs[0], pairs[1]
+		log.Printf("k=%v,v=%v", k, v)
+		switch k {
+		case "a":
+			log.Printf("av=%v", v)
+			if v != "" {
+				allowed = strings.Split(v, ",")
+			}
+			log.Printf("allowed=%v", allowed)
+		case "r":
+			log.Printf("rv=%v", v)
+			if v != "" {
+				required = strings.Split(v, ",")
+				allowed = set.Strings(allowed)
+			}
+		}
+	}
+	required = set.Strings(required)
+	allowed = append(allowed, required...)
+	allowed = set.Strings(allowed)
+	return parsedParam{field.Name, field.Type.Name(), key, allowed, required}
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,49 @@
+package hyperdrive
+
+func (suite *HyperdriveTestSuite) TestTagName() {
+	suite.Equal("param", tagName, "expects tagName to be correct")
+}
+
+func (suite *HyperdriveTestSuite) TestIsAllowedTrue() {
+	suite.Equal(true, suite.TestParsedParam.IsAllowed("GET"), "expects it to return true")
+}
+
+func (suite *HyperdriveTestSuite) TestIsAllowedFalse() {
+	suite.Equal(false, suite.TestParsedParam.IsAllowed("POST"), "expects it to return false")
+}
+
+func (suite *HyperdriveTestSuite) TestIsRequiredTrue() {
+	suite.Equal(true, suite.TestParsedParam.IsRequired("PUT"), "expects it to return true")
+}
+
+func (suite *HyperdriveTestSuite) TestIsRequiredFalse() {
+	suite.Equal(false, suite.TestParsedParam.IsRequired("POST"), "expects it to return false")
+}
+
+func (suite *HyperdriveTestSuite) TestContainsTrue() {
+	suite.Equal(true, contains([]string{"GET"}, "GET"), "expects it to return true")
+}
+
+func (suite *HyperdriveTestSuite) TestContainsFalse() {
+	suite.Equal(false, contains([]string{"GET"}, "POST"), "expects it to return false")
+}
+
+func (suite *HyperdriveTestSuite) TestParse() {
+	suite.IsType(map[string]parsedParam{}, parse(suite.TestTaggedStruct), "expects it to return a map of parsedParams")
+}
+
+func (suite *HyperdriveTestSuite) TestParseTestParam() {
+	suite.Equal(suite.TestParsedParamMap["test_param"], parse(suite.TestTaggedStruct)["test_param"], "expects it to return the correct parsedParam")
+}
+
+func (suite *HyperdriveTestSuite) TestParseTestParamDefault() {
+	suite.Equal(suite.TestParsedParamMap["test_param_default"], parse(suite.TestTaggedStruct)["test_param_default"], "expects it to return the correct parsedParam")
+}
+
+func (suite *HyperdriveTestSuite) TestParseTestParamEmpty() {
+	suite.Equal(suite.TestParsedParamMap["TestParamEmpty"], parse(suite.TestTaggedStruct)["TestParamEmpty"], "expects it to return the correct parsedParam")
+}
+
+func (suite *HyperdriveTestSuite) TestParseTestParamRequired() {
+	suite.Equal(suite.TestParsedParamMap["test_param_required"], parse(suite.TestTaggedStruct)["test_param_required"], "expects it to return the correct parsedParam")
+}


### PR DESCRIPTION
Given an `Endpointer` struct like this one:

```go
type TaggedStruct struct {
	*Endpoint
	TestParam         string `param:"test_param;a=GET,PUT;r=PUT"`
	TestParamDefault  string `param:"test_param_default"`
	TestParamEmpty    string `param:""`
	TestParamRequired string `param:"test_param_required;a=GET;r=PUT"`
}
```

We apply the following parsing rules:

- `TestParam` has specified `test_param` as the `key` which will map the
incoming input from an HTTP request to the field on the endpoint. It has
also specified `GET` and `PUT` requests to allow the param. Other
requests will strip it out (when that gets implemented). It has
specified `PUT` to require the param. `PUT` requests will throw an error
if `test_param` is not present in the request (when that gets implemented).
- `TestParamDefault` has specified a `key` of `test_param_default`. It
will default to allowing the param on `GET`, `PATCH`, `POST` and `PUT`
requests, and not require it on any of those allowed requests.
- `TestParamEmpty` has not specified any directives, and will use
`TestParamEmpty` as the `key`. It will allow the param on `GET`, `PATCH`,
`POST` and `PUT` requests, which is the default, and not require it on
any of the allowed requests.
- `TestParamRequired` will allow and require `PUT` requests, even though
`PUT` was omitted from the `allowed` list.

fixes #49