### PR TITLE
adds support for parsing allowed/required params

### DIFF
--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -10,11 +10,16 @@ import (
 )
 
 type TaggedStruct struct {
-	*Endpoint
+	Endpoint
 	TestParam         string `param:"test_param;a=GET,PUT;r=PUT"`
 	TestParamDefault  string `param:"test_param_default"`
 	TestParamEmpty    string `param:""`
 	TestParamRequired string `param:"test_param_required;a=GET;r=PUT"`
+}
+
+type TaggedEndpoint struct {
+	Endpoint
+	ID string `param:"id;r=GET"`
 }
 
 type HyperdriveTestSuite struct {
@@ -25,13 +30,15 @@ type HyperdriveTestSuite struct {
 	TestRoot                *RootResource
 	TestEndpointResource    EndpointResource
 	TestGetRequest          *http.Request
+	TestGetRequestNoParams  *http.Request
 	TestPostRequest         *http.Request
 	TestParsedParam         parsedParam
 	TestParsedParamDefault  parsedParam
 	TestParsedParamEmpty    parsedParam
 	TestParsedParamRequired parsedParam
-	TestTaggedStruct        TaggedStruct
-	TestParsedParamMap      map[string]parsedParam
+	TestTaggedStruct        *TaggedStruct
+	TestParsedParamMap      parsedParams
+	TestTaggedEndpoint      *TaggedEndpoint
 }
 
 func (suite *HyperdriveTestSuite) SetupTest() {
@@ -41,13 +48,15 @@ func (suite *HyperdriveTestSuite) SetupTest() {
 	suite.TestRoot = NewRootResource(suite.TestAPI)
 	suite.TestEndpointResource = NewEndpointResource(suite.TestEndpoint)
 	suite.TestGetRequest = httptest.NewRequest("GET", "/test/2?id=1&a=b", nil)
+	suite.TestGetRequestNoParams = httptest.NewRequest("GET", "/test", nil)
 	suite.TestPostRequest = httptest.NewRequest("POST", "/test/2?id=1&a=b", strings.NewReader(`{"id":3}`))
 	suite.TestParsedParam = parsedParam{"TestParam", "string", "test_param", []string{"GET", "PUT"}, []string{"PUT"}}
 	suite.TestParsedParamDefault = parsedParam{"TestParamDefault", "string", "test_param_default", []string{"GET", "PATCH", "POST", "PUT"}, []string{}}
 	suite.TestParsedParamEmpty = parsedParam{"TestParamEmpty", "string", "TestParamEmpty", []string{"GET", "PATCH", "POST", "PUT"}, []string{}}
 	suite.TestParsedParamRequired = parsedParam{"TestParamRequired", "string", "test_param_required", []string{"GET", "PUT"}, []string{"PUT"}}
-	suite.TestParsedParamMap = map[string]parsedParam{"test_param": suite.TestParsedParam, "test_param_default": suite.TestParsedParamDefault, "TestParamEmpty": suite.TestParsedParamEmpty, "test_param_required": suite.TestParsedParamRequired}
-	suite.TestTaggedStruct = TaggedStruct{}
+	suite.TestParsedParamMap = parsedParams{"test_param": suite.TestParsedParam, "test_param_default": suite.TestParsedParamDefault, "TestParamEmpty": suite.TestParsedParamEmpty, "test_param_required": suite.TestParsedParamRequired}
+	suite.TestTaggedStruct = &TaggedStruct{Endpoint: *NewEndpoint("Test", "Test Endpoint", "/test", "1.0.1-beta")}
+	suite.TestTaggedEndpoint = &TaggedEndpoint{Endpoint: *NewEndpoint("Test", "Test Endpoint", "/test", "1.0.1-beta")}
 }
 
 func (suite *HyperdriveTestSuite) TestNewAPI() {

--- a/params.go
+++ b/params.go
@@ -1,6 +1,8 @@
 package hyperdrive
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -56,4 +58,25 @@ func Params(r *http.Request) url.Values {
 	}
 
 	return params
+}
+
+// GetParams returns all allowed request params. It returns an error on
+// the first required param is not present. GetParams is intended to be used
+// in your method handlers in a given endpoint.
+func GetParams(e Endpointer, r *http.Request) (url.Values, error) {
+	pp := parseEndpoint(e)
+	p := Params(r)
+	for k := range p {
+		log.Println("k=%v,contains=%v", k, pp.Allowed(r.Method))
+		if contains(pp.Allowed(r.Method), k) != true {
+			p.Del(k)
+		}
+	}
+
+	for _, required := range pp.Required(r.Method) {
+		if k, ok := p[required]; !ok {
+			return p, fmt.Errorf("Missing required parameter: %s", k)
+		}
+	}
+	return p, nil
 }

--- a/params_test.go
+++ b/params_test.go
@@ -66,3 +66,15 @@ func (suite *HyperdriveTestSuite) TestParamsNonGetValues() {
 	}))
 	suite.TestAPI.Router.ServeHTTP(httptest.NewRecorder(), suite.TestPostRequest)
 }
+
+func (suite *HyperdriveTestSuite) TestGetParams() {
+	params, err := GetParams(suite.TestTaggedEndpoint, suite.TestGetRequest)
+	suite.Equal(url.Values{"id": []string{"1"}}, params, "returns populated url.Values")
+	suite.Nil(err, "returns populated url.Values")
+}
+
+func (suite *HyperdriveTestSuite) TestGetParamsError() {
+	params, err := GetParams(suite.TestTaggedEndpoint, suite.TestGetRequestNoParams)
+	suite.Equal(url.Values{}, params, "returns populated url.Values")
+	suite.Error(err, "returns populated url.Values")
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -29,21 +29,21 @@ func (suite *HyperdriveTestSuite) TestContainsFalse() {
 }
 
 func (suite *HyperdriveTestSuite) TestParse() {
-	suite.IsType(map[string]parsedParam{}, parse(suite.TestTaggedStruct), "expects it to return a map of parsedParams")
+	suite.IsType(parsedParams{}, parseEndpoint(suite.TestTaggedStruct), "expects it to return a map of parsedParams")
 }
 
 func (suite *HyperdriveTestSuite) TestParseTestParam() {
-	suite.Equal(suite.TestParsedParamMap["test_param"], parse(suite.TestTaggedStruct)["test_param"], "expects it to return the correct parsedParam")
+	suite.Equal(suite.TestParsedParamMap["test_param"], parseEndpoint(suite.TestTaggedStruct)["test_param"], "expects it to return the correct parsedParam")
 }
 
 func (suite *HyperdriveTestSuite) TestParseTestParamDefault() {
-	suite.Equal(suite.TestParsedParamMap["test_param_default"], parse(suite.TestTaggedStruct)["test_param_default"], "expects it to return the correct parsedParam")
+	suite.Equal(suite.TestParsedParamMap["test_param_default"], parseEndpoint(suite.TestTaggedStruct)["test_param_default"], "expects it to return the correct parsedParam")
 }
 
 func (suite *HyperdriveTestSuite) TestParseTestParamEmpty() {
-	suite.Equal(suite.TestParsedParamMap["TestParamEmpty"], parse(suite.TestTaggedStruct)["TestParamEmpty"], "expects it to return the correct parsedParam")
+	suite.Equal(suite.TestParsedParamMap["TestParamEmpty"], parseEndpoint(suite.TestTaggedStruct)["TestParamEmpty"], "expects it to return the correct parsedParam")
 }
 
 func (suite *HyperdriveTestSuite) TestParseTestParamRequired() {
-	suite.Equal(suite.TestParsedParamMap["test_param_required"], parse(suite.TestTaggedStruct)["test_param_required"], "expects it to return the correct parsedParam")
+	suite.Equal(suite.TestParsedParamMap["test_param_required"], parseEndpoint(suite.TestTaggedStruct)["test_param_required"], "expects it to return the correct parsedParam")
 }


### PR DESCRIPTION
- adds `GetParams()` function to be used in method handlers for getting
only allowed params and returning an error if any required params are
missing.

fixes #42